### PR TITLE
Fix issues #24 and #31

### DIFF
--- a/src/main/java/doctor4t/astronomical/client/render/world/AstraWorldVFXBuilder.java
+++ b/src/main/java/doctor4t/astronomical/client/render/world/AstraWorldVFXBuilder.java
@@ -14,7 +14,6 @@ import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import team.lodestar.lodestone.helpers.RenderHelper;
 import team.lodestar.lodestone.setup.LodestoneRenderLayers;
-import team.lodestar.lodestone.setup.LodestoneShaders;
 import team.lodestar.lodestone.systems.rendering.Phases;
 import team.lodestar.lodestone.systems.rendering.VFXBuilders;
 
@@ -22,8 +21,8 @@ import java.awt.*;
 
 public class AstraWorldVFXBuilder extends VFXBuilders.WorldVFXBuilder {
 	public static final LodestoneRenderLayers.RenderLayerProvider TEXTURE_ACTUAL_TRIANGLE = new LodestoneRenderLayers.RenderLayerProvider((texture) -> LodestoneRenderLayers.createGenericRenderLayer(texture.getNamespace(), "texture_actual_triangle", VertexFormats.POSITION_COLOR_TEXTURE, VertexFormat.DrawMode.TRIANGLES, RenderPhase.POSITION_COLOR_TEXTURE_LIGHTMAP_SHADER, Phases.NO_TRANSPARENCY, texture));
-	public static final LodestoneRenderLayers.RenderLayerProvider TEXTURE_ACTUAL_TRIANGLE_TRANSPARENT = new LodestoneRenderLayers.RenderLayerProvider((texture) -> LodestoneRenderLayers.createGenericRenderLayer(texture.getNamespace(), "texture_actual_triangle_transparent", VertexFormats.POSITION_COLOR_TEXTURE_LIGHT, VertexFormat.DrawMode.TRIANGLES, LodestoneShaders.LODESTONE_TEXTURE.phase, Phases.NORMAL_TRANSPARENCY, texture));
-	public static final LodestoneRenderLayers.RenderLayerProvider TEXTURE_ACTUAL_TRIANGLE_ADDITIVE = new LodestoneRenderLayers.RenderLayerProvider((texture) -> LodestoneRenderLayers.createGenericRenderLayer(texture.getNamespace(), "texture_actual_triangle_additive", VertexFormats.POSITION_COLOR_TEXTURE_LIGHT, VertexFormat.DrawMode.TRIANGLES, LodestoneShaders.LODESTONE_TEXTURE.phase, Phases.ADDITIVE_TRANSPARENCY, texture));
+	public static final LodestoneRenderLayers.RenderLayerProvider TEXTURE_ACTUAL_TRIANGLE_TRANSPARENT = new LodestoneRenderLayers.RenderLayerProvider((texture) -> LodestoneRenderLayers.createGenericRenderLayer(texture.getNamespace(), "texture_actual_triangle_transparent", VertexFormats.POSITION_COLOR_TEXTURE_LIGHT, VertexFormat.DrawMode.TRIANGLES, Phases.POSITION_COLOR_TEXTURE_LIGHTMAP_SHADER, Phases.NORMAL_TRANSPARENCY, texture));
+	public static final LodestoneRenderLayers.RenderLayerProvider TEXTURE_ACTUAL_TRIANGLE_ADDITIVE = new LodestoneRenderLayers.RenderLayerProvider((texture) -> LodestoneRenderLayers.createGenericRenderLayer(texture.getNamespace(), "texture_actual_triangle_additive", VertexFormats.POSITION_COLOR_TEXTURE_LIGHT, VertexFormat.DrawMode.TRIANGLES, Phases.POSITION_COLOR_TEXTURE_LIGHTMAP_SHADER, Phases.ADDITIVE_TRANSPARENCY, texture));
 
 	public AstraWorldVFXBuilder() {
 


### PR DESCRIPTION
- Modified so that vanilla `color_tex_light` layers are used instead of Lodestone's
- Tried to update the todo screen particles, but unsure where they're supposed to appear so haven't been able to test
<br>

- There were some Z-ordering issues with transparency (in particular fluids) but I haven't seen them in a while
- [Outer Wilds Spoiler] still allows the particle (on top of astral display) through, not sure if this is intended behaviour